### PR TITLE
ci: run system tests nightly and post-submit

### DIFF
--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -1,14 +1,16 @@
-name: System Tests
+name: System Tests (PR)
 
 on:
-  push:
-    branches: master
-  schedule:
-    - cron: 0 2 * * *
+  pull_request_target:
+    types: [ labeled ]
 
 jobs:
   build:
     name: System Tests
+    # Since this has access to secrets, only run if the PR has manually been
+    # deemed 'safe' to run by a maintainer.
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    if: ${{ github.event.label.name == 'run-ci' }}
     runs-on: ubuntu-latest
     env:
       BACKENDS: "bigquery"
@@ -19,6 +21,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,8 +1,12 @@
 name: System Tests
 
 on:
+  push:
+    branches: master
   pull_request_target:
     types: [ labeled ]
+  schedule:
+    - cron: 0 2 * * *
 
 jobs:
   build:
@@ -10,14 +14,19 @@ jobs:
     # Since this has access to secrets, only run if the PR has manually been
     # deemed 'safe' to run by a maintainer.
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    if: ${{ github.event.label.name == 'run-ci' }}
+    if: ${{
+      github.event.type != 'PullRequestEvent'
+      || (
+        github.event.type == 'PullRequestEvent'
+        && github.event.label.name == 'run-ci'
+      ) }}
     runs-on: ubuntu-latest
     env:
       BACKENDS: "bigquery"
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.7", "3.9"]
+        python_version: ["3.7", "3.8", "3.9"]
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Ibis BigQuery backend
 
-ibis-bigquery package
+This package provides a [BigQuery](https://cloud.google.com/bigquery) backend
+for [Ibis](https://ibis-project.org/).
+

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -x
+
+python -m pip install --upgrade pip
+python -m pip install ./ibis
+python -m pip install .
+python -m pip install pytest


### PR DESCRIPTION
Uses two separate workflows (one for PRs and one for nightly/push) because I found the logic for skipping tests based on the event type to be quite error-prone. Also, the checkout logic is different, since the nightly/push workflow needs to be run at HEAD.

Closes #7 