### PR TITLE
Check for negative values before doing substr

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -242,7 +242,7 @@ def _string_right(translator, expr):
 def _string_substring(translator, expr):
     op = expr.op()
     arg, start, length = op.args
-    if length < 0:
+    if length.op().value < 0:
         raise ValueError('Length parameter should not be a negative value.')
 
     arg_formatted = translator.translate(arg)

--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -239,6 +239,29 @@ def _string_right(translator, expr):
     )
 
 
+def _string_substring(translator, expr):
+    op = expr.op()
+    arg, start, length = op.args
+    if length < 0:
+        raise ValueError('Length parameter should not be a negative value.')
+
+    arg_formatted = translator.translate(arg)
+    start_formatted = translator.translate(start)
+    if length is None or isinstance(length.op(), ops.Literal):
+        lvalue = length.op().value if length is not None else None
+        if lvalue:
+            return 'substr({}, {} + 1, {})'.format(
+                arg_formatted, start_formatted, lvalue
+            )
+        else:
+            return 'substr({}, {} + 1)'.format(arg_formatted, start_formatted)
+    else:
+        length_formatted = translator.translate(length)
+        return 'substr({}, {} + 1, {})'.format(
+            arg_formatted, start_formatted, length_formatted
+        )
+
+
 def _array_literal_format(expr):
     return str(list(expr.op().value))
 
@@ -388,6 +411,7 @@ _operation_registry.update(
         ops.StringJoin: _string_join,
         ops.StringAscii: _string_ascii,
         ops.StringFind: _string_find,
+        ops.Substring: _string_substring,
         ops.StrRight: _string_right,
         ops.Repeat: fixed_arity('REPEAT', 2),
         ops.RegexSearch: _regex_search,

--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -245,21 +245,8 @@ def _string_substring(translator, expr):
     if length.op().value < 0:
         raise ValueError('Length parameter should not be a negative value.')
 
-    arg_formatted = translator.translate(arg)
-    start_formatted = translator.translate(start)
-    if length is None or isinstance(length.op(), ops.Literal):
-        lvalue = length.op().value if length is not None else None
-        if lvalue:
-            return 'substr({}, {} + 1, {})'.format(
-                arg_formatted, start_formatted, lvalue
-            )
-        else:
-            return 'substr({}, {} + 1)'.format(arg_formatted, start_formatted)
-    else:
-        length_formatted = translator.translate(length)
-        return 'substr({}, {} + 1, {})'.format(
-            arg_formatted, start_formatted, length_formatted
-        )
+    base_substring = operation_registry[ops.Substring]
+    base_substring(translator, expr)
 
 
 def _array_literal_format(expr):

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -258,6 +258,14 @@ FROM t"""
     assert result == expected
 
 
+def test_substring():
+    t = ibis.table([('value', 'string')], name='t')
+    expr = t["value"].substr(3, -1)
+    with pytest.raises(Exception) as exception_info:
+        ibis.bigquery.compile(expr)
+    assert str(exception_info.value) == 'Length parameter should not be a negative value.'
+
+
 def test_bucket():
     t = ibis.table([('value', 'double')], name='t')
     buckets = [0, 1, 3]

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -262,8 +262,10 @@ def test_substring():
     t = ibis.table([('value', 'string')], name='t')
     expr = t["value"].substr(3, -1)
     with pytest.raises(Exception) as exception_info:
-        ibis.bigquery.compile(expr)
-    assert str(exception_info.value) == 'Length parameter should not be a negative value.'
+        ibis_bigquery.compile(expr)
+
+    expected = 'Length parameter should not be a negative value.'
+    assert str(exception_info.value) == expected
 
 
 def test_bucket():


### PR DESCRIPTION
hey @tswast ,

I took a swing at https://github.com/ibis-project/ibis/issues/1629

What I'd have wanted was to use the `ibis.backends.base.sql.string.registry.substring` method but that requires changes to the `ibis.backends.base.sql.registry.__init__.py` and so on to make it visible here.
For the time being I copied the `substring` implementation here, but I could open a PR on the `ibis` repo to make the `substring` method visible, and then we could use it here directly.
Anyway, let me know what you think