### PR TITLE
fix: use TIMESTAMP_SUB for TimstampSub operation

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -419,7 +419,7 @@ _operation_registry.update(
             'TIMESTAMP_ADD', {'h', 'm', 's', 'ms', 'us'}
         ),
         ops.TimestampSub: _timestamp_op(
-            'TIMESTAMP_DIFF', {'h', 'm', 's', 'ms', 'us'}
+            'TIMESTAMP_SUB', {'h', 'm', 's', 'ms', 'us'}
         ),
         ops.DateAdd: _timestamp_op('DATE_ADD', {'D', 'W', 'M', 'Q', 'Y'}),
         ops.DateSub: _timestamp_op('DATE_SUB', {'D', 'W', 'M', 'Q', 'Y'}),


### PR DESCRIPTION
Incorrect SQL expression was specified for TimestampSub.