### PR TITLE
build: set release-please language

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,3 +1,4 @@
 primaryBranch: main
 releaseLabels: run-ci
+releaseType: python
 handleGHRelease: true


### PR DESCRIPTION
For some reason, I had to set this when I ran the release-please NPM. Maybe it's not detecting Python automatically?