### PR TITLE
test: use correct packaging.version import

### DIFF
--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -6,7 +6,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import numpy as np
-import packaging
+import packaging.version
 import pandas as pd
 import pandas.testing as tm
 import pytest


### PR DESCRIPTION
I was getting a "packaging does not have attribute version" error before this change (but only on one of my conda environments for some reason).

Towards #56
