### PR TITLE
Add timediff as another time operationr function

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -468,6 +468,7 @@ _operation_registry.update(
         ops.Time: unary("TIME"),
         ops.TimestampAdd: _timestamp_op("TIMESTAMP_ADD", {"h", "m", "s", "ms", "us"}),
         ops.TimestampSub: _timestamp_op("TIMESTAMP_SUB", {"h", "m", "s", "ms", "us"}),
+		ops.TimestampDiff: _timestamp_op('TIME_DIFF', {'h', 'm', 's', 'ms', 'us'}),
         ops.DateAdd: _timestamp_op("DATE_ADD", {"D", "W", "M", "Q", "Y"}),
         ops.DateSub: _timestamp_op("DATE_SUB", {"D", "W", "M", "Q", "Y"}),
         ops.TimestampNow: fixed_arity("CURRENT_TIMESTAMP", 0),

--- a/tests/system/test_compiler.py
+++ b/tests/system/test_compiler.py
@@ -1,5 +1,6 @@
 import ibis
 import ibis.expr.datatypes as dt
+import ibis.expr.api as api
 import packaging.version
 import pytest
 
@@ -34,6 +35,20 @@ UNION {expected_keyword}
 SELECT *
 FROM `{project_id}.testing.functional_alltypes`"""
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('distinct', 'expected_keyword'), [(True, 'DISTINCT'), (False, 'ALL')]
+    'operand', [lambda t: api.time('18:00'), lambda t: t.k]
+)
+@pytest.mark.parametrize('unit', ['h', 'm', 's', 'ms', 'us', 'ns'])
+def test_timestamp_timediff(operand, unit):
+    # import pytest;
+    # pytest.set_trace()
+    table = ibis.table([('c', 'timestamp')], name='t')
+    expr = operand(table).timediff(unit)
+    # assert isinstance(expr, ir.TimeValue)
+    # assert isinstance(expr.op(), ops.TimestampDiff)
 
 
 def test_ieee_divide(alltypes, project_id):


### PR DESCRIPTION
closes #41 

baed on https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time_diff and https://github.com/ibis-project/ibis-bigquery/pull/40/files#r620526603 I added a `TIME_DIFF`

hey @tswast  I tried adding a unit test but it is not working :( 
I am getting the following errors
```
FAILED tests/system/test_compiler.py::test_timestamp_timediff[h-<lambda>0] - AttributeError: 'TimeScalar' object has no attribute 'timediff'
FAILED tests/system/test_compiler.py::test_timestamp_timediff[h-<lambda>1] - AttributeError: k
```
any suggestions/advice please?