### PR TITLE
Fix converting regex to raw string

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -143,21 +143,16 @@ def _string_find(translator, expr):
     )
 
 
-def _translate_pattern(translator, pattern):
-    # add 'r' to string literals to indicate to BigQuery this is a raw string
-    return "r" * isinstance(pattern.op(), ops.Literal) + translator.translate(pattern)
-
-
 def _regex_search(translator, expr):
     arg, pattern = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_CONTAINS({}, {})".format(translator.translate(arg), regex)
     return result
 
 
 def _regex_extract(translator, expr):
     arg, pattern, index = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_EXTRACT_ALL({}, {})[SAFE_OFFSET({})]".format(
         translator.translate(arg), regex, translator.translate(index)
     )
@@ -166,7 +161,7 @@ def _regex_extract(translator, expr):
 
 def _regex_replace(translator, expr):
     arg, pattern, replacement = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_REPLACE({}, {}, {})".format(
         translator.translate(arg), regex, translator.translate(replacement)
     )


### PR DESCRIPTION
@cpcloud @tswast Thoughts?

Fixes issue where regexes passed into `re_search` among other `re` functions in the `ibis` library were being converted to strings prefixed with `r'my_original_string'` which seems less than useful if `'my_original_string'` is a regex.

Before generated BigQuery would look like:
```SQL
SELECT *
FROM `my_project.my_dataset.my_table`
WHERE REGEXP_CONTAINS(`field`, r'(some_message_\\(\\(&some_signal\\)\\))')
```
whereas now it looks like:
```SQL
SELECT *
FROM `my_project.my_dataset.my_table`
WHERE REGEXP_CONTAINS(`field`, '(some_message_\\(\\(&some_signal\\)\\))')
```

Will close #110 