### PR TITLE
fix: escape regex literals in `regexp_contains`

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -143,21 +143,16 @@ def _string_find(translator, expr):
     )
 
 
-def _translate_pattern(translator, pattern):
-    # add 'r' to string literals to indicate to BigQuery this is a raw string
-    return "r" * isinstance(pattern.op(), ops.Literal) + translator.translate(pattern)
-
-
 def _regex_search(translator, expr):
     arg, pattern = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_CONTAINS({}, {})".format(translator.translate(arg), regex)
     return result
 
 
 def _regex_extract(translator, expr):
     arg, pattern, index = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_EXTRACT_ALL({}, {})[SAFE_OFFSET({})]".format(
         translator.translate(arg), regex, translator.translate(index)
     )
@@ -166,7 +161,7 @@ def _regex_extract(translator, expr):
 
 def _regex_replace(translator, expr):
     arg, pattern, replacement = expr.op().args
-    regex = _translate_pattern(translator, pattern)
+    regex = translator.translate(pattern)
     result = "REGEXP_REPLACE({}, {}, {})".format(
         translator.translate(arg), regex, translator.translate(replacement)
     )

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -332,3 +332,21 @@ def test_large_compile():
     table.compile()
     delta = datetime.datetime.now() - start
     assert delta.total_seconds() < 10
+
+
+def test_regex_strings_are_not_raw():
+    schema = [
+        ("field", "string"),
+        ("val", "int64"),
+    ]
+    table = ibis.table(schema, name="unbound_table")
+
+    expr = table[table['field'].re_search('(foo)')]
+    result = ibis_bigquery.compile(expr)
+
+    expected = """\
+SELECT *
+FROM unbound_table
+WHERE REGEXP_CONTAINS(`field`, '(foo)')"""
+
+    assert result == expected and expected.index(", '") + 1 != 'r'


### PR DESCRIPTION
@cpcloud @tswast Thoughts?

Fixes issue where regexes passed into `re_search` among other `re` functions in the `ibis` library were being converted to strings prefixed with `r'my_original_string'` which seems less than useful if `'my_original_string'` is a regex. The string I am trying to filter on looks like `some_message_((&some_signal))`
Before generated BigQuery would look like:
```SQL
SELECT *
FROM `my_project.my_dataset.my_table`
WHERE REGEXP_CONTAINS(`field`, r'(some_message_\\(\\(&some_signal\\)\\))')
```
whereas now it looks like:
```SQL
SELECT *
FROM `my_project.my_dataset.my_table`
WHERE REGEXP_CONTAINS(`field`, '(some_message_\\(\\(&some_signal\\)\\))')
```

Will close #110 