### PR TITLE
feat: Raise better error message when incorrect dataset is supplied #113

### DIFF
--- a/ibis_bigquery/client.py
+++ b/ibis_bigquery/client.py
@@ -319,7 +319,13 @@ def parse_project_and_dataset(project: str, dataset: str = "") -> Tuple[str, str
     None
 
     """
-    if "." in dataset:
+    if dataset.count(".") > 1:
+        raise ValueError(
+            "{} is not a BigQuery dataset. More info https://cloud.google.com/bigquery/docs/datasets-intro".format(
+                dataset
+            )
+        )
+    elif dataset.count(".") == 1:
         data_project, dataset = dataset.split(".")
         billing_project = project
     else:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -22,10 +22,8 @@ def test_parse_project_and_dataset(project, dataset, expected):
 
 
 def test_parse_project_and_dataset_raises_error():
-    with pytest.raises(ValueError) as exception:
+    expected_message = "data-project.my_dataset.table is not a BigQuery dataset"
+    with pytest.raises(ValueError, match=expected_message):
         ibis_bigquery.client.parse_project_and_dataset(
             "my-project", "data-project.my_dataset.table"
         )
-    assert "data-project.my_dataset.table is not a BigQuery dataset" in str(
-        exception.value
-    )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -19,3 +19,13 @@ import ibis_bigquery.client
 def test_parse_project_and_dataset(project, dataset, expected):
     got = ibis_bigquery.client.parse_project_and_dataset(project, dataset)
     assert got == expected
+
+
+def test_parse_project_and_dataset_raises_error():
+    with pytest.raises(ValueError) as exception:
+        ibis_bigquery.client.parse_project_and_dataset(
+            "my-project", "data-project.my_dataset.table"
+        )
+    assert "data-project.my_dataset.table is not a BigQuery dataset" in str(
+        exception.value
+    )


### PR DESCRIPTION
```py
In [1]: import ibis
   ...: import ibis_bigquery
   ...:
   ...: conn = ibis_bigquery.connect(
   ...:     project_id="voltron-data-developers",
   ...:     dataset_id="bigquery-public-data.pypi.dataset",
   ...: )
   ```
```py
--------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [1], in <module>
      1 import ibis
      2 import ibis_bigquery
----> 4 conn = ibis_bigquery.connect(
      5     project_id="voltron-data-developers",
      6     dataset_id="bigquery-public-data.pypi.dataset",
      7 )

File ~/workspace/ibis-bigquery/ibis_bigquery/__init__.py:426, in connect(project_id, dataset_id, credentials, application_name, auth_local_webserver, auth_external_data, auth_cache, partition_column)
    378 """Create a :class:`Backend` for use with Ibis.
    379
    380 Parameters
   (...)
    423
    424 """
    425 backend = Backend()
--> 426 return backend.connect(
    427     project_id=project_id,
    428     dataset_id=dataset_id,
    429     credentials=credentials,
    430     application_name=application_name,
    431     auth_local_webserver=auth_local_webserver,
    432     auth_external_data=auth_external_data,
    433     auth_cache=auth_cache,
    434     partition_column=partition_column,
    435 )

File ~/workspace/ibis-bigquery/ibis_bigquery/__init__.py:148, in Backend.connect(self, project_id, dataset_id, credentials, application_name, auth_local_webserver, auth_external_data, auth_cache, partition_column)
    140 project_id = project_id or default_project_id
    142 new_backend = self.__class__()
    144 (
    145     new_backend.data_project,
    146     new_backend.billing_project,
    147     new_backend.dataset,
--> 148 ) = parse_project_and_dataset(project_id, dataset_id)
    150 new_backend.client = bq.Client(
    151     project=new_backend.billing_project,
    152     credentials=credentials,
    153     client_info=_create_client_info(application_name),
    154 )
    155 new_backend.partition_column = partition_column

File ~/workspace/ibis-bigquery/ibis_bigquery/client.py:323, in parse_project_and_dataset(project, dataset)
    279 """Compute the billing project, data project, and dataset if available.
    280
    281 This function figure out the project id under which queries will run versus
   (...)
    320
    321 """
    322 if dataset.count(".") > 1:
--> 323     raise ValueError(
    324         "{} is not a BigQuery dataset. More info https://cloud.google.com/bigquery/docs/datasets-intro".format(
    325             dataset
    326         )
    327     )
    328 elif dataset.count(".") == 1:
    329     data_project, dataset = dataset.split(".")

ValueError: bigquery-public-data.pypi.dataset is not a BigQuery dataset. More info https://cloud.google.com/bigquery/docs/datasets-intro
```

