### PR TITLE
fix: avoid deprecated "out-of-band" authentication flow

### DIFF
--- a/ibis_bigquery/__init__.py
+++ b/ibis_bigquery/__init__.py
@@ -54,7 +54,7 @@ class Backend(BaseSQLBackend):
         dataset_id: str = "",
         credentials: Optional[google.auth.credentials.Credentials] = None,
         application_name: Optional[str] = None,
-        auth_local_webserver: bool = False,
+        auth_local_webserver: bool = True,
         auth_external_data: bool = False,
         auth_cache: str = "default",
         partition_column: Optional[str] = "PARTITIONTIME",

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -598,7 +598,7 @@ def test_multiple_project_queries_execute(client):
 
 
 def test_large_timestamp(client):
-    huge_timestamp = datetime.datetime(year=4567, month=1, day=1, tzinfo=datetime.timezone.utc)
+    huge_timestamp = datetime.datetime(year=4567, month=1, day=1)
     expr = ibis.timestamp("4567-01-01 00:00:00")
     result = client.execute(expr)
     assert result == huge_timestamp

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -598,10 +598,10 @@ def test_multiple_project_queries_execute(client):
 
 
 def test_large_timestamp(client):
-    huge_timestamp = datetime.datetime(year=4567, month=1, day=1)
+    huge_timestamp = datetime.datetime(year=4567, month=1, day=1, tzinfo=datetime.timezone.utc)
     expr = ibis.timestamp("4567-01-01 00:00:00")
     result = client.execute(expr)
-    assert result == huge_timestamp
+    assert result.astimezone(datetime.timezone.utc) == huge_timestamp
 
 
 def test_string_to_timestamp(client):

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -598,7 +598,9 @@ def test_multiple_project_queries_execute(client):
 
 
 def test_large_timestamp(client):
-    huge_timestamp = datetime.datetime(year=4567, month=1, day=1, tzinfo=datetime.timezone.utc)
+    huge_timestamp = datetime.datetime(
+        year=4567, month=1, day=1, tzinfo=datetime.timezone.utc
+    )
     expr = ibis.timestamp("4567-01-01 00:00:00")
     result = client.execute(expr)
     assert result.astimezone(datetime.timezone.utc) == huge_timestamp

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -598,7 +598,7 @@ def test_multiple_project_queries_execute(client):
 
 
 def test_large_timestamp(client):
-    huge_timestamp = datetime.datetime(year=4567, month=1, day=1)
+    huge_timestamp = datetime.datetime(year=4567, month=1, day=1, tzinfo=datetime.timezone.utc)
     expr = ibis.timestamp("4567-01-01 00:00:00")
     result = client.execute(expr)
     assert result == huge_timestamp


### PR DESCRIPTION
The console-based copy-paste-a-token flow has been deprecated. See:
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob