### PR TITLE
fix: update to UDFContext for trans_numeric_udf function

### DIFF
--- a/ibis_bigquery/datatypes.py
+++ b/ibis_bigquery/datatypes.py
@@ -111,6 +111,6 @@ def trans_numeric(t, context):
     return "NUMERIC"
 
 
-@ibis_type_to_bigquery_type.register(dt.Decimal, TypeTranslationContext)
+@ibis_type_to_bigquery_type.register(dt.Decimal, UDFContext)
 def trans_numeric_udf(t, context):
     raise TypeError("Decimal types are not supported in BigQuery UDFs")


### PR DESCRIPTION
The `trans_numeric` and `trans_numeric_udf` functions have the same signature and this prevents registering the NUMERIC data type correctly.

This PR updates the `trans_numeric_udf` function to use the correct context.