### PR TITLE
ci: fix ibis version computation and update tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       with:
         repository: ibis-project/ibis
         path: ibis
+        fetch-depth: 0
 
     - name: set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -50,8 +50,11 @@ jobs:
     - name: checkout ibis
       uses: actions/checkout@v3
       with:
+        # fetch depth 0 is necessary to ensure that the development version is
+        # computed from a tag and not computed as one commit past 0.0.0
         repository: ibis-project/ibis
         path: ibis
+        fetch-depth: 0
 
     - name: install dependencies (ibis ${{ matrix.ibis_version }})
       env:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         repository: ibis-project/ibis
         path: ibis
+        fetch-depth: 0
 
     - name: install dependencies (ibis ${{ matrix.ibis_version }})
       env:

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -13,6 +13,7 @@ import ibis_bigquery
 IBIS_VERSION = packaging.version.Version(ibis.__version__)
 IBIS_1_4_VERSION = packaging.version.Version("1.4.0")
 IBIS_3_0_VERSION = packaging.version.Version("3.0.0")
+IBIS_3_0_2_VERSION = packaging.version.Version("3.0.2")
 
 
 @pytest.mark.parametrize(
@@ -45,7 +46,8 @@ IBIS_3_0_VERSION = packaging.version.Version("3.0.0")
 def test_literal_date(case, expected, dtype):
     expr = ibis.literal(case, type=dtype).year()
     result = ibis_bigquery.compile(expr)
-    assert result == f"SELECT EXTRACT(year from {expected}) AS `tmp`"
+    expected_name = "tmp" if IBIS_VERSION <= IBIS_3_0_2_VERSION else "year"
+    assert result == f"SELECT EXTRACT(year from {expected}) AS `{expected_name}`"
 
 
 @pytest.mark.parametrize(
@@ -214,7 +216,8 @@ def test_hashbytes(case, expected, how, dtype):
 def test_literal_timestamp_or_time(case, expected, dtype):
     expr = ibis.literal(case, type=dtype).hour()
     result = ibis_bigquery.compile(expr)
-    assert result == f"SELECT EXTRACT(hour from {expected}) AS `tmp`"
+    expected_name = "tmp" if IBIS_VERSION <= IBIS_3_0_2_VERSION else "hour"
+    assert result == f"SELECT EXTRACT(hour from {expected}) AS `{expected_name}`"
 
 
 def test_projection_fusion_only_peeks_at_immediate_parent():


### PR DESCRIPTION
After running locally with ibis `master` and getting different results with the
same commit (`df66acb2c918f97b848798adfb11defcf3aed1da`) than the
`ibis-bigquery` CI I investigated and noticed that the version for the
checked-out ibis `master` is showing up as
`ibis_framework-0.0.0.post1+df66acb.dirty`
[here](https://github.com/ibis-project/ibis-bigquery/runs/6596747186?check_suite_focus=true#step:5:222).

`poetry-dynamic-versioning` needs history for accurate version computation so
I've added that here and will address any additional test failures.

