### PR TITLE
feat: partial support for integer to timestamp with nanosecond units

### DIFF
--- a/ibis_bigquery/compiler.py
+++ b/ibis_bigquery/compiler.py
@@ -101,26 +101,25 @@ def _cast(translator, expr):
     return bigquery_cast(arg_formatted, arg.type(), target_type)
 
 
-def integer_to_timestamp(translator: compiler.ExprTranslator,
-                         expr: ibis.Expr) -> str:
-  """Interprets an integer as a timestamp."""
-  op = expr.op()
-  arg, unit = op.args
-  arg = translator.translate(arg)
+def integer_to_timestamp(translator: compiler.ExprTranslator, expr: ibis.Expr) -> str:
+    """Interprets an integer as a timestamp."""
+    op = expr.op()
+    arg, unit = op.args
+    arg = translator.translate(arg)
 
-  if unit == 's':
-    return 'TIMESTAMP_SECONDS({})'.format(arg)
-  elif unit == 'ms':
-    return 'TIMESTAMP_MILLIS({})'.format(arg)
-  elif unit == 'us':
-    return 'TIMESTAMP_MICROS({})'.format(arg)
-  elif unit == 'ns':
-    # Timestamps are represented internally as elapsed microseconds, so some
-    # rounding is required if an integer represents nanoseconds.
-    # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
-    return 'TIMESTAMP_MICROS(CAST(ROUND({} / 1000) AS INT64))'.format(arg)
+    if unit == "s":
+        return "TIMESTAMP_SECONDS({})".format(arg)
+    elif unit == "ms":
+        return "TIMESTAMP_MILLIS({})".format(arg)
+    elif unit == "us":
+        return "TIMESTAMP_MICROS({})".format(arg)
+    elif unit == "ns":
+        # Timestamps are represented internally as elapsed microseconds, so some
+        # rounding is required if an integer represents nanoseconds.
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
+        return "TIMESTAMP_MICROS(CAST(ROUND({} / 1000) AS INT64))".format(arg)
 
-  raise NotImplementedError('cannot cast unit {}'.format(unit))
+    raise NotImplementedError("cannot cast unit {}".format(unit))
 
 
 def _struct_field(translator, expr):

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -220,7 +220,7 @@ def test_integer_to_timestamp(case, unit, expected):
     expr = ibis.literal(case, type=dt.int64).to_timestamp(unit=unit)
     result = ibis_bigquery.compile(expr)
     assert result == f"SELECT {expected} AS `tmp`"
-    
+
 
 @pytest.mark.parametrize(
     ("case", "expected", "dtype"),


### PR DESCRIPTION
BigQuery only supports microsecond-precision timestamps https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type, but if someone knows they want a timestamp data type, I think it's better to do the conversion than to fail with unsupported units.