### PR TITLE
fix(compat): fix failing approx methods against ibis `master`

### DIFF
--- a/ibis_bigquery/registry.py
+++ b/ibis_bigquery/registry.py
@@ -486,8 +486,9 @@ def _try_register_op(op_name: str, value):
 
     This allows us to decouple slightly from ibis-framework releases.
     """
-    if hasattr(ops, op_name):
-        OPERATION_REGISTRY[getattr(ops, op_name)] = value
+    op = getattr(ops, op_name, None)
+    if op is not None:
+        OPERATION_REGISTRY[op] = value
 
 
 # 2.x

--- a/ibis_bigquery/registry.py
+++ b/ibis_bigquery/registry.py
@@ -494,6 +494,8 @@ def _try_register_op(op_name: str, value):
 _try_register_op("BitAnd", reduction("BIT_AND"))
 _try_register_op("BitOr", reduction("BIT_OR"))
 _try_register_op("BitXor", reduction("BIT_XOR"))
+_try_register_op("ApproxCountDistinct", reduction("APPROX_COUNT_DISTINCT"))
+_try_register_op("ApproxMedian", compiles_approx)
 
 
 _invalid_operations = {


### PR DESCRIPTION
Closes #141.
