### PR TITLE
docs(README): make note that the bigquery backend is now upstream

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,12 @@
+Change of Address
+=================
+
+The `BigQuery <https://cloud.google.com/bigquery>`_ backend is now maintained
+as a first-party backend in `Ibis <https://github.com/ibis-project/ibis>`_.
+
+You can find updated installation and usage instructions in the `Ibis
+documentation <https://ibis-project.org/backends/BigQuery/>`_.
+
 Ibis BigQuery backend
 =====================
 


### PR DESCRIPTION
I thought we should add a note directing any visitors -- do we also want to archive this repository?